### PR TITLE
Add to contrib after loading 'sly.

### DIFF
--- a/sly-package-inferred-autoloads.el
+++ b/sly-package-inferred-autoloads.el
@@ -3,7 +3,8 @@
 ;;;;;;  (21964 37122 0 0))
 ;;; Generated autoloads from sly-package-inferred.el
 
-(add-to-list 'sly-contribs 'sly-package-inferred 'append)
+(with-eval-after-load 'sly
+  (add-to-list 'sly-contribs 'sly-package-inferred 'append))
 
 ;;;***
 

--- a/sly-package-inferred.el
+++ b/sly-package-inferred.el
@@ -35,6 +35,7 @@ in `sly-editing-mode-hook', i.e. lisp files."
 
 ;;; Automatically add ourselves to `sly-contribs' when this file is loaded
 ;;;###autoload
-(add-to-list 'sly-contribs 'sly-package-inferred 'append)
+(with-eval-after-load 'sly
+  (add-to-list 'sly-contribs 'sly-package-inferred 'append))
 
 (provide 'sly-package-inferred)


### PR DESCRIPTION
Else the load would fail if the package happens to be loaded before SLY.